### PR TITLE
fixed nzbindex search

### DIFF
--- a/src/nzbmonkey.py
+++ b/src/nzbmonkey.py
@@ -683,6 +683,10 @@ class NZBDownload(object):
             print(Col.WARN + ' Connection Error' + Col.OFF, flush=True)
             return False, None
 
+        if res.status_code != requests.codes.ok:
+            print(Col.WARN + ' SERVICE DOWN: ' + res.reason + Col.OFF, flush=True)
+            return False, None
+        
         m = re.search(self.regex, res.text)
         if m is None:
             print(Col.WARN + ' NOT FOUND' + Col.OFF, flush=True)
@@ -742,7 +746,7 @@ def search_nzb(header, password, search_engines, best_nzb, max_missing_files, ma
                 'name': 'BinSearch',
                 'searchUrl': 'https://binsearch.info/?q={0}&max=100&adv_age=1100&server=',
                 'regex': r'name="(?P<id>\d{9,})"',
-                'downloadUrl': 'http://www.binsearch.info/?action=nzb&{id}=1',
+                'downloadUrl': 'https://www.binsearch.info/?action=nzb&{id}=1',
                 'skip_segment_debug': False
             },
         'binsearch_alternative':
@@ -750,7 +754,7 @@ def search_nzb(header, password, search_engines, best_nzb, max_missing_files, ma
                 'name': 'BinSearch - Alternative Server',
                 'searchUrl': 'https://binsearch.info/?q={0}&max=100&adv_age=1100&server=2',
                 'regex': r'name="(?P<id>\d{9,})"',
-                'downloadUrl': 'http://www.binsearch.info/?action=nzb&{id}=1&server=2',
+                'downloadUrl': 'https://www.binsearch.info/?action=nzb&{id}=1&server=2',
                 'skip_segment_debug': False
             },
         'nzbking':
@@ -764,17 +768,17 @@ def search_nzb(header, password, search_engines, best_nzb, max_missing_files, ma
         'nzbindex':
             {
                 'name': 'NZBIndex',
-                'searchUrl': 'http://nzbindex.com/search/?q={0}&sort=agedesc&hidespam=1',
-                'regex': r'label for="box(?P<id>\d{8,})".*?class="highlight"',
-                'downloadUrl': 'http://nzbindex.com/download/{id}/',
-                'skip_segment_debug': False
-            },
-        'nzbindex_beta':
-            {
-                'name': 'NZBIndex Beta',
-                'searchUrl': 'http://beta.nzbindex.com/search/rss?q={0}&hidespam=1&sort=agedesc&complete=1',
-                'regex': r'<link>http:\/\/beta\.nzbindex\.com\/download\/(?P<id>\d{8,})<\/link>',
-                'downloadUrl': 'http://beta.nzbindex.com/download/{id}.nzb?r[]={id}',
+                'searchUrl': 'https://beta.nzbindex.com/search/rss?q={0}&hidespam=1&sort=agedesc',
+                'regex': r'<link>http:\/\/beta\.nzbindex\.com\/download\/(?P<id>\d{8,})\/<\/link>',
+                'downloadUrl': 'https://beta.nzbindex.com/download/{id}/',
+
+
+
+
+
+
+
+
                 'skip_segment_debug': False
             },
         'newzleech':
@@ -1499,7 +1503,6 @@ def main():
                                                     cfg['Searchengines'].as_int('binsearch_alternative'),
                                                 'nzbking': cfg['Searchengines'].as_int('nzbking'),
                                                 'nzbindex': cfg['Searchengines'].as_int('nzbindex'),
-                                                'nzbindex_beta': cfg['Searchengines'].as_int('nzbindex_beta'),
                                                 'newzleech': cfg['Searchengines'].as_int('newzleech')},
                                                cfg['NZBCheck'].as_bool('best_nzb'),
                                                cfg['NZBCheck'].get('max_missing_files', 2),

--- a/src/nzbmonkeyspec.py
+++ b/src/nzbmonkeyspec.py
@@ -111,8 +111,6 @@ binsearch =  integer(default = 1)
 binsearch_alternative = integer(default = 1)
 # Enable NZBIndex
 nzbindex =  integer(default = 1)
-# Enable NZBIndex Beta
-nzbindex_beta =  integer(default = 1)
 # Enable NZBKing
 nzbking =  integer(default = 1)
 # Enable Newzleech

--- a/src/version.py
+++ b/src/version.py
@@ -2,6 +2,17 @@
 """
 
 History
+
+v0.2.5.1
+- modded
+
+v0.2.5
+- NzbindexBeta removed, its out of beta
+- Fixed NzbKing (good for old nzblnks)
+
+v0.2.4
+- NzbindexBeta indexer regex fix
+
 v0.2.3
 - NzbindexBeta indexer added
 
@@ -72,5 +83,5 @@ v0.1.0
 
 """
 
-__version__ = '0.2.3'
+__version__ = '0.2.5.1'
 __requires__ = ['pyperclip', 'requests', 'configobj', 'colorama', 'cryptography']


### PR DESCRIPTION
- replaced nzbindex with nzbindex_beta settings (old method does no longer work)
- fixed beta.nzbindex.com search
- checking website return codes, e.g. 503 - service unavailable
- enabled https where possible