### PR TITLE
fix object comparing an empty literal

### DIFF
--- a/src/nzbmonkey.py
+++ b/src/nzbmonkey.py
@@ -1445,7 +1445,7 @@ def main():
 
         clip = pyperclip.paste()
 
-        if clip is None or clip is '':
+        if clip is None or clip == '':
             print_and_wait(' Clipboard is empty. So please call {} <nzblnk> or with text in clipboard.'.format(
                 basename(sys.argv[0])),
                 WAITING_TIME_LONG)


### PR DESCRIPTION
Python 3.8 complains about object comparing an empty literal

/usr/src/nzbmonkey/nzbmonkey.py:1448: SyntaxWarning: "is" with a literal. Did you mean "=="?
