### PR TITLE
Don't error out when a provider sends bad data or fails

### DIFF
--- a/src/nzbmonkey.py
+++ b/src/nzbmonkey.py
@@ -345,34 +345,37 @@ class NZBParser(object):
         context = self.get_etree_iter(self.nzb)
         current_file, current_segment = None, None
 
-        for event, elem in context:
-            if event == 'start':
-                # If it's an NZBFile, create an object so that we can add the
-                # appropriate stuff to it.
-                if elem.tag == '{http://www.newzbin.com/DTD/2003/nzb}file':
-                    current_file = NZBFile(
-                        poster=elem.attrib['poster'],
-                        date=elem.attrib['date'],
-                        subject=elem.attrib['subject'],
-                        debug=self.debug)
+        try:
+            for event, elem in context:
+                if event == 'start':
+                    # If it's an NZBFile, create an object so that we can add the
+                    # appropriate stuff to it.
+                    if elem.tag == '{http://www.newzbin.com/DTD/2003/nzb}file':
+                        current_file = NZBFile(
+                            poster=elem.attrib['poster'],
+                            date=elem.attrib['date'],
+                            subject=elem.attrib['subject'],
+                            debug=self.debug)
 
-            elif event == 'end':
-                if elem.tag == '{http://www.newzbin.com/DTD/2003/nzb}file':
-                    self.files.append(current_file)
+                elif event == 'end':
+                    if elem.tag == '{http://www.newzbin.com/DTD/2003/nzb}file':
+                        self.files.append(current_file)
 
-                elif elem.tag == '{http://www.newzbin.com/DTD/2003/nzb}group':
-                    current_file.add_group(elem.text)
+                    elif elem.tag == '{http://www.newzbin.com/DTD/2003/nzb}group':
+                        current_file.add_group(elem.text)
 
-                elif elem.tag == '{http://www.newzbin.com/DTD/2003/nzb}segment':
-                    current_file.add_segment(
-                        NZBSegment(
-                            bytes_=elem.attrib['bytes'],
-                            number=elem.attrib['number'],
-                            message_id=elem.text
+                    elif elem.tag == '{http://www.newzbin.com/DTD/2003/nzb}segment':
+                        current_file.add_segment(
+                            NZBSegment(
+                                bytes_=elem.attrib['bytes'],
+                                number=elem.attrib['number'],
+                                message_id=elem.text
+                            )
                         )
-                    )
-                # Clear the element, we don't need it any more.
-                elem.clear()
+                    # Clear the element, we don't need it any more.
+                    elem.clear()
+        except Exception:
+            pass
 
     def determine_expected_files(self, nzbfile):
         """Determine expected files


### PR DESCRIPTION
```
 - Searching NZB - Search for best NZB enabled
   with BinSearch ... NOT FOUND
   with BinSearch - Alternative Server ... DONE
Traceback (most recent call last):
  File "./nzbmonkey.py", line 1751, in <module>
    sys.exit(main())
  File "./nzbmonkey.py", line 1506, in main
    debug)
  File "./nzbmonkey.py", line 828, in search_nzb
    search_defs[engine]['skip_segment_debug'])
  File "./nzbmonkey.py", line 291, in __init__
    self.parse()
  File "./nzbmonkey.py", line 348, in parse
    for event, elem in context:
  File "/usr/lib/python3.6/xml/etree/ElementTree.py", line 1227, in iterator
    root = pullparser._close_and_return_root()
  File "/usr/lib/python3.6/xml/etree/ElementTree.py", line 1274, in _close_and_return_root
    root = self._parser.close()
xml.etree.ElementTree.ParseError: no element found: line 1, column 0

```

Pretty dirty patch, but works.
This is how it looks with the patched file:

```
 - Searching NZB - Search for best NZB enabled
   with BinSearch ... NOT FOUND
   with BinSearch - Alternative Server ... DONE
   - Check NZB (Max. 2 missing files - Max. 2.0% missing Segments)
     Check file count ... Skip - No information found
     Check segments ...
     Overall result: Skip - No information found
   with NZBKing ... DONE
   - Check NZB (Max. 2 missing files - Max. 2.0% missing Segments)
     Check file count ... Skip - No information found
     Check segments ...
     Overall result: OK - File count is unknown - Segment check is OK
   with NZBIndex ... Timeout
   with Newzleech ... Timeout

   use NZB from NZBKing
     Upload age:      110 days
 - Pushing to NZBGET ... OK
 - Done

```
